### PR TITLE
Target Keycloak 23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 	</developers>
 
 	<properties>
-		<keycloak.version>22.0.0</keycloak.version>
+		<keycloak.version>23.0.0</keycloak.version>
 
 		<maven.compiler.target>17</maven.compiler.target>
 		<maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProvider.java
+++ b/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProvider.java
@@ -98,7 +98,7 @@ public class CasIdentityProvider extends AbstractIdentityProvider<CasIdentityPro
     return new Endpoint(callback, realm, event, this);
   }
 
-  public final class Endpoint {
+  public static final class Endpoint {
     private final AuthenticationCallback callback;
     private final RealmModel realm;
     private final EventBuilder event;
@@ -106,6 +106,7 @@ public class CasIdentityProvider extends AbstractIdentityProvider<CasIdentityPro
     private final ClientConnection clientConnection;
     private final HttpHeaders headers;
     private final CasIdentityProvider provider;
+    private final CasIdentityProviderConfig config;
 
     Endpoint(
         final AuthenticationCallback callback,
@@ -119,6 +120,7 @@ public class CasIdentityProvider extends AbstractIdentityProvider<CasIdentityPro
       this.session = provider.session;
       this.headers = session.getContext().getRequestHeaders();
       this.clientConnection = session.getContext().getConnection();
+      this.config = provider.getConfig();
     }
 
     @GET
@@ -126,7 +128,6 @@ public class CasIdentityProvider extends AbstractIdentityProvider<CasIdentityPro
         @QueryParam(PROVIDER_PARAMETER_TICKET) final String ticket,
         @QueryParam(PROVIDER_PARAMETER_STATE) final String state) {
       try {
-        CasIdentityProviderConfig config = getConfig();
         BrokeredIdentityContext federatedIdentity =
             getFederatedIdentity(config, ticket, session.getContext().getUri(), state);
 


### PR DESCRIPTION
Attempting to fix build failure

```
ERROR: Build failure: Build failed due to errors
	[error]: Build step io.quarkus.resteasy.reactive.server.deployment.ResteasyReactiveProcessor#setupEndpoints threw an exception: java.lang.RuntimeException: jakarta.enterprise.inject.spi.DeploymentException: Non static nested resources classes are not supported: 'io.github.johnjcool.keycloak.broker.cas.CasIdentityProvider$Endpoint'
	at org.jboss.resteasy.reactive.common.processor.EndpointIndexer.createEndpoints(EndpointIndexer.java:321)
	at io.quarkus.resteasy.reactive.server.deployment.ResteasyReactiveProcessor.setupEndpoints(ResteasyReactiveProcessor.java:696)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:864)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:282)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
	at java.base/java.lang.Thread.run(Thread.java:840)
	at org.jboss.threads.JBossThread.run(JBossThread.java:501)
Caused by: jakarta.enterprise.inject.spi.DeploymentException: Non static nested resources classes are not supported: 'io.github.johnjcool.keycloak.broker.cas.CasIdentityProvider$Endpoint'
	at org.jboss.resteasy.reactive.common.processor.EndpointIndexer.createEndpoints(EndpointIndexer.java:269)
	... 12 more```