### PR TITLE
Change sign out behaviour

### DIFF
--- a/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProvider.java
+++ b/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProvider.java
@@ -89,7 +89,7 @@ public class CasIdentityProvider extends AbstractIdentityProvider<CasIdentityPro
       return ErrorPage.error(
         session, null, Response.Status.INTERNAL_SERVER_ERROR, "CAS KC Logout Failed");
     }
-    if(config.isBackchannelLogout()){
+    if(config.isCasLogout()){
       return Response.status(302)
         .location(createLogoutUrl(getConfig(), realm, uriInfo).build())
         .build();

--- a/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProvider.java
+++ b/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProvider.java
@@ -79,24 +79,23 @@ public class CasIdentityProvider extends AbstractIdentityProvider<CasIdentityPro
       final UriInfo uriInfo,
       final RealmModel realm) {
     CasIdentityProviderConfig config = getConfig();
-    Response res = AuthenticationManager.finishBrowserLogout(
-      session, realm, userSession, uriInfo, session.getContext().getConnection(), null);
+    Response res =
+        AuthenticationManager.finishBrowserLogout(
+            session, realm, userSession, uriInfo, session.getContext().getConnection(), null);
     if (res.getStatus() != 302) {
       logger.error("Failed to logout user session: " + userSession.getId());
       EventBuilder event = new EventBuilder(realm, session, session.getContext().getConnection());
       event.event(EventType.LOGOUT);
       event.error(Errors.USER_SESSION_NOT_FOUND);
-      return ErrorPage.error(
-        session, null, Response.Status.BAD_REQUEST, "CAS KC Logout Failed");
+      return ErrorPage.error(session, null, Response.Status.BAD_REQUEST, "CAS KC Logout Failed");
     }
-    if(config.isBackchannelLogout()){
+    if (config.isBackchannelLogout()) {
       return Response.status(302)
-        .location(createLogoutUrl(getConfig(), realm, uriInfo).build())
-        .build();
+          .location(createLogoutUrl(getConfig(), realm, uriInfo).build())
+          .build();
     }
     return res;
   }
-
 
   @Override
   public Response retrieveToken(

--- a/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProvider.java
+++ b/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProvider.java
@@ -79,24 +79,24 @@ public class CasIdentityProvider extends AbstractIdentityProvider<CasIdentityPro
       final UriInfo uriInfo,
       final RealmModel realm) {
     CasIdentityProviderConfig config = getConfig();
-    Response res = AuthenticationManager.finishBrowserLogout(
-      session, realm, userSession, uriInfo, session.getContext().getConnection(), null);
+    Response res =
+        AuthenticationManager.finishBrowserLogout(
+            session, realm, userSession, uriInfo, session.getContext().getConnection(), null);
     if (res.getStatus() != 302) {
       logger.error("Failed to logout user session: " + userSession.getId());
       EventBuilder event = new EventBuilder(realm, session, session.getContext().getConnection());
       event.event(EventType.LOGOUT);
       event.error(Errors.USER_SESSION_NOT_FOUND);
       return ErrorPage.error(
-        session, null, Response.Status.INTERNAL_SERVER_ERROR, "CAS KC Logout Failed");
+          session, null, Response.Status.INTERNAL_SERVER_ERROR, "CAS KC Logout Failed");
     }
-    if(config.isCasLogout()){
+    if (config.isCasLogout()) {
       return Response.status(302)
-        .location(createLogoutUrl(getConfig(), realm, uriInfo).build())
-        .build();
+          .location(createLogoutUrl(getConfig(), realm, uriInfo).build())
+          .build();
     }
     return res;
   }
-
 
   @Override
   public Response retrieveToken(

--- a/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProviderConfig.java
+++ b/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProviderConfig.java
@@ -44,6 +44,14 @@ public class CasIdentityProviderConfig extends IdentityProviderModel {
     return Boolean.parseBoolean(getConfig().get("renew"));
   }
 
+  public void setBackchannelLogout(final boolean backchannelLogout) {
+    getConfig().put("backchannellogout", String.valueOf(backchannelLogout));
+  }
+
+  public boolean isBackchannelLogout() {
+    return Boolean.parseBoolean(getConfig().get("backchannellogout"));
+  }
+
   public String getCasServerLoginUrl() {
     return String.format("%s/%s", getConfig().get("casServerUrlPrefix"), DEFAULT_CAS_LOGIN_SUFFIX);
   }

--- a/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProviderConfig.java
+++ b/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProviderConfig.java
@@ -44,12 +44,12 @@ public class CasIdentityProviderConfig extends IdentityProviderModel {
     return Boolean.parseBoolean(getConfig().get("renew"));
   }
 
-  public void setBackchannelLogout(final boolean backchannelLogout) {
-    getConfig().put("backchannellogout", String.valueOf(backchannelLogout));
+  public void setCasLogout(final boolean casLogout) {
+    getConfig().put("redirectToCasServerAfterLogout", String.valueOf(casLogout));
   }
 
-  public boolean isBackchannelLogout() {
-    return Boolean.parseBoolean(getConfig().get("backchannellogout"));
+  public boolean isCasLogout() {
+    return Boolean.parseBoolean(getConfig().get("redirectToCasServerAfterLogout"));
   }
 
   public String getCasServerLoginUrl() {

--- a/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProviderFactory.java
+++ b/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProviderFactory.java
@@ -56,9 +56,9 @@ public class CasIdentityProviderFactory extends AbstractIdentityProviderFactory<
         .helpText("Do not force users to authenticate if they are not already authenticated.")
         .add()
         .property()
-        .name("backchannellogout")
+        .name("redirectToCasServerAfterLogout")
         .type(ProviderConfigProperty.BOOLEAN_TYPE)
-        .label("Backchannel Logout")
+        .label("CAS Logout")
         .helpText("Should the user also be logged out of CAS when they log out of keycloak?")
         .add()
         .build();

--- a/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProviderFactory.java
+++ b/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProviderFactory.java
@@ -37,24 +37,30 @@ public class CasIdentityProviderFactory extends AbstractIdentityProviderFactory<
   @Override
   public List<ProviderConfigProperty> getConfigProperties() {
     return ProviderConfigurationBuilder.create()
-        .property()
+      .property()
         .name("casServerUrlPrefix")
         .type(ProviderConfigProperty.STRING_TYPE)
         .label("CAS server URL prefix")
         .helpText("The start of the CAS server URL, i.e. https://localhost:8443/cas")
         .add()
-        .property()
+      .property()
         .name("renew")
         .type(ProviderConfigProperty.BOOLEAN_TYPE)
         .label("CAS renew")
         .helpText("Force users to reauthenticate.")
         .add()
-        .property()
+      .property()
         .name("gateway")
         .type(ProviderConfigProperty.BOOLEAN_TYPE)
         .label("CAS gateway")
         .helpText("Do not force users to authenticate if they are not already authenticated.")
         .add()
-        .build();
+      .property()
+        .name("backchannellogout")
+        .type(ProviderConfigProperty.BOOLEAN_TYPE)
+        .label("Backchannel Logout")
+        .helpText("Should the user also be logged out of CAS when they log out of keycloak?")
+        .add()
+      .build();
   }
 }

--- a/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProviderFactory.java
+++ b/src/main/java/io/github/johnjcool/keycloak/broker/cas/CasIdentityProviderFactory.java
@@ -37,30 +37,30 @@ public class CasIdentityProviderFactory extends AbstractIdentityProviderFactory<
   @Override
   public List<ProviderConfigProperty> getConfigProperties() {
     return ProviderConfigurationBuilder.create()
-      .property()
+        .property()
         .name("casServerUrlPrefix")
         .type(ProviderConfigProperty.STRING_TYPE)
         .label("CAS server URL prefix")
         .helpText("The start of the CAS server URL, i.e. https://localhost:8443/cas")
         .add()
-      .property()
+        .property()
         .name("renew")
         .type(ProviderConfigProperty.BOOLEAN_TYPE)
         .label("CAS renew")
         .helpText("Force users to reauthenticate.")
         .add()
-      .property()
+        .property()
         .name("gateway")
         .type(ProviderConfigProperty.BOOLEAN_TYPE)
         .label("CAS gateway")
         .helpText("Do not force users to authenticate if they are not already authenticated.")
         .add()
-      .property()
+        .property()
         .name("backchannellogout")
         .type(ProviderConfigProperty.BOOLEAN_TYPE)
         .label("Backchannel Logout")
         .helpText("Should the user also be logged out of CAS when they log out of keycloak?")
         .add()
-      .build();
+        .build();
   }
 }


### PR DESCRIPTION
This PR changes sign out behaviour to always end a keycloak session when sign out is intitiated from keycloak and optionally adds the ability for a user's CAS session to be ended at the same time. 

Unsure if these changes are wanted but this is how I would expect the IdP to behave, hence I'm proposing this fix. 